### PR TITLE
bump up version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.0
+
+- Add support for 256-bit keys
+
 # Version 0.1.2
 
 - Add missing crates.io doc link

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libaes"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Han Xu <keepsimple@gmail.com>"]
 edition = "2018"
 description = "AES cipher in safe Rust"


### PR DESCRIPTION
Bump up minor version as we added support for 256-bit keys.