### PR TITLE
bump up to version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.0
+- API change: return an error type for cbc_decrypt
+- Update README
+
 # Version 0.4.0
 
 - Add support for CFB128 mode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libaes"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Han Xu <keepsimple@gmail.com>"]
 edition = "2018"
-description = "AES cipher in safe Rust"
+description = "AES cipher in safe Rust with no dependencies"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/keepsimple1/libaes"
 documentation = "https://docs.rs/libaes"

--- a/README.md
+++ b/README.md
@@ -3,36 +3,18 @@
 [![Build](https://github.com/keepsimple1/libaes/workflows/Build%20and%20Test/badge.svg)](https://github.com/keepsimple1/libaes/actions)
 [![Cargo](https://img.shields.io/crates/v/libaes.svg)](https://crates.io/crates/libaes)
 
-This is a re-implementation of AES in safe Rust, with zero dependencies. The core algorithm is ported
-from AES core in [OpenSSL 1.1.1 stable](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/aes/aes_core.c).
-This library strives to be:
+This is a small implementation of AES in safe Rust, with no dependencies. The core algorithm is ported
+from AES core of [OpenSSL 1.1.1 stable](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/aes/aes_core.c).
+It is hardware-independent and fast (for example, as of January 2021, its AES-128 CBC mode is more than 3X faster than
+RustCrypto [`aes`](https://crates.io/crates/aes) + [`block-modes`](https://crates.io/crates/block-modes) crates,
+see [benchmark](https://github.com/keepsimple1/libaes-utils/blob/main/README.md#Benchmark)).
 
-- Correct (as the original OpenSSL implementation)
-- Fast (as OpenSSL 1.1.1)
-- Safe Rust code only.
-- Small: no dependencies.
+Currently, this library supports:
 
-Currently, this library supports 128-bit, 192-bit and 256-bit keys with CBC mode and CFB128 mode.
+- CBC mode: 128-bit, 192-bit and 256-bit keys
+- CFB128 mode
 
-## Examples
-
-```rust
-use libaes::Cipher;
-
-let my_key = b"This is the key!"; // key is 128-bit (16 bytes)
-let plaintext = b"A plaintext";
-let iv = b"This is 16 bytes";
-
-// Create a new cipher
-let cipher = Cipher::new_128(my_key);
-
-// Encryption
-let encrypted = cipher.cbc_encrypt(iv, plaintext);
-
-// Decryption
-let decrypted = cipher.cbc_decrypt(iv, &encrypted[..]);
-
-```
+See [Documentation](https://docs.rs/libaes/) for examples and [tests](tests).
 
 ## Correctness
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! - Safe Rust code only.
 //! - Zero dependencies.
-//! - Fast (thanks to algorithms in OpenSSL 1.1.1).
+//! - Fast (thanks to algorithms in OpenSSL 1.1.1, see some [benchmark](https://github.com/keepsimple1/libaes-utils/blob/main/README.md#Benchmark)).
 //!
 //! Currently, this cipher supports 128-bit, 192-bit and 256-bit keys with the following modes:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! - Safe Rust code only.
 //! - Zero dependencies.
-//! - Fast (as OpenSSL 1.1.1).
+//! - Fast (thanks to algorithms in OpenSSL 1.1.1).
 //!
 //! Currently, this cipher supports 128-bit, 192-bit and 256-bit keys with the following modes:
 //!
@@ -337,6 +337,9 @@ impl std::fmt::Display for CipherError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.text().as_str())
     }
+}
+
+impl std::error::Error for CipherError {
 }
 
 // PKCS7 padding: a new Vec is returned with padding.


### PR DESCRIPTION
We need to bump up the minor version due to API change in `cbc_decrypt`.
