### PR TITLE
Reverse API change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! let encrypted = cipher.cbc_encrypt(iv, plaintext);
 //!
 //! // Decryption
-//! let decrypted = cipher.cbc_decrypt(iv, &encrypted[..]).unwrap();
+//! let decrypted = cipher.cbc_decrypt(iv, &encrypted[..]);
 //! ```
 
 #![forbid(unsafe_code)]
@@ -164,8 +164,8 @@ impl Cipher {
 
     /// Decrypt in CBC mode.
     ///
-    /// The input data is not modified. The output is a new Vec if successful, otherwise an error
-    /// is returned. Padding is handled automatically.
+    /// The input data is not modified. The output is a new Vec. Padding is handled automatically.
+    /// If decrypt was not successful, the output is an empty Vec.
     ///
     /// `iv` is a 16-byte slice. Panics if `iv` is less than 16 bytes.
     ///
@@ -183,10 +183,10 @@ impl Cipher {
     ///                    \xa3\x16\xb6\xd4\x35\x6d\x2b\x6f\x49\xff\x9e\x3c\xe4\x66\x16\xb9";
     ///
     /// let cipher = Cipher::new_128(my_key);
-    /// let decrypted = cipher.cbc_decrypt(iv, ciphertext).unwrap();
+    /// let decrypted = cipher.cbc_decrypt(iv, ciphertext);
     /// assert_eq!(plaintext, &decrypted[..]);
     /// ```
-    pub fn cbc_decrypt(&self, iv: &[u8], data: &[u8]) -> Result<Vec<u8>, CipherError> {
+    pub fn cbc_decrypt(&self, iv: &[u8], data: &[u8]) -> Vec<u8> {
         let length = data.len();
         let mut new = data.to_vec();
         let mut my_iv = iv;
@@ -197,10 +197,8 @@ impl Cipher {
             xor_with_iv(block, my_iv);
             my_iv = &data[i..i + AES_BLOCK_SIZE];
         }
-        match unpad(&mut new) {
-            Ok(()) => Ok(new),
-            Err(e) => Err(e.add_context("cbc_decrypt")),
-        }
+        unpad(&mut new);
+        new
     }
 
     /// Encrypt in CFB128 mode (i.e. CFB mode with 128-bit segment size).
@@ -290,58 +288,6 @@ impl Cipher {
     }
 }
 
-/// The only error type reported by `libaes`. It is minimum and has a context list
-/// that shows a simplified compact backtrace.
-///
-/// Example output:
-///
-/// ```text
-/// libaes.cbc_decrypt.UnpadError: Corrupted padded bytes, possible invalid key
-/// ```
-#[derive(Debug)]
-pub struct CipherError {
-    context: Vec<String>, // acts as a backtrace
-    message: String,
-}
-
-impl CipherError {
-    fn new(context: &str, message: &str) -> Self {
-        let context = vec![context.to_string()];
-        let message = message.to_string();
-        Self {
-            context,
-            message,
-        }
-    }
-
-    /// Return a String representation of this error.
-    ///
-    /// This string is same as what `fmt::Display` trait outputs.
-    fn text(&self) -> String {
-        let mut context = "".to_string();
-        for c in self.context.iter() {
-            context += ".";
-            context += c;
-        }
-        format!("libaes{}: {}", &context, &self.message)
-    }
-
-    // Add a new context at the top of the context list
-    fn add_context(mut self, context: &str) -> Self {
-        self.context.insert(0, context.to_string());
-        self
-    }
-}
-
-impl std::fmt::Display for CipherError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.text().as_str())
-    }
-}
-
-impl std::error::Error for CipherError {
-}
-
 // PKCS7 padding: a new Vec is returned with padding.
 fn pad(input: &[u8]) -> Vec<u8> {
     let sz = input.len();
@@ -355,18 +301,12 @@ fn pad(input: &[u8]) -> Vec<u8> {
 }
 
 // PKCS7 un-padding in-place: the input Vec is truncated as needed if successful,
-// otherwise the input is not modified and an error is returned.
-fn unpad(padded: &mut Vec<u8>) -> Result<(), CipherError> {
+// otherwise truncated to empty.
+fn unpad(padded: &mut Vec<u8>) {
     let sz = padded.len();
     let added = padded[sz - 1] as usize;
-    if sz < added {
-        return Err(CipherError::new(
-            "UnpadError",
-            "Corrupted padded bytes, possible invalid key",
-        ));
-    }
-    padded.truncate(sz - added);
-    Ok(())
+    let unpad_sz = if sz > added { sz - added } else { 0 };
+    padded.truncate(unpad_sz);
 }
 
 // bit-wise XOR `buf` slice with `iv` slice

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ impl Cipher {
     /// Decrypt in CBC mode.
     ///
     /// The input data is not modified. The output is a new Vec. Padding is handled automatically.
-    /// If decrypt was not successful, the output is an empty Vec.
+    /// If decrypt encounted unexpected errors, the output is an empty Vec.
     ///
     /// `iv` is a 16-byte slice. Panics if `iv` is less than 16 bytes.
     ///

--- a/tests/aes.rs
+++ b/tests/aes.rs
@@ -32,7 +32,7 @@ fn nist_verify_aes_128_cbc() {
     assert_eq!(encrypted.len(), len_without_padding + padding_size);
     assert_eq!(encrypted[..len_without_padding], ciphertext[..]);
 
-    let decrypted = cipher.cbc_decrypt(NIST_IV, &encrypted[..]).unwrap();
+    let decrypted = cipher.cbc_decrypt(NIST_IV, &encrypted[..]);
     assert_eq!(decrypted[..], plaintext[..]);
 }
 
@@ -56,7 +56,7 @@ fn nist_verify_aes_192_cbc() {
     assert_eq!(encrypted.len(), len_without_padding + padding_size);
     assert_eq!(encrypted[..len_without_padding], ciphertext[..]);
 
-    let decrypted = cipher.cbc_decrypt(NIST_IV, &encrypted[..]).unwrap();
+    let decrypted = cipher.cbc_decrypt(NIST_IV, &encrypted[..]);
     assert_eq!(decrypted[..], plaintext[..]);
 }
 
@@ -80,7 +80,7 @@ fn nist_verify_aes_256_cbc() {
     assert_eq!(encrypted.len(), len_without_padding + padding_size);
     assert_eq!(encrypted[..len_without_padding], ciphertext[..]);
 
-    let decrypted = cipher.cbc_decrypt(NIST_IV, &encrypted[..]).unwrap();
+    let decrypted = cipher.cbc_decrypt(NIST_IV, &encrypted[..]);
     assert_eq!(decrypted[..], plaintext[..]);
 }
 
@@ -157,7 +157,7 @@ fn small_data() {
     let iv = b"This is 16 bytes";
     let encrypted_128 = cipher.cbc_encrypt(iv, plaintext);
     assert_eq!(encrypted_128.len(), 16); // Verify padding
-    let decrypted_128 = cipher.cbc_decrypt(iv, &encrypted_128[..]).unwrap();
+    let decrypted_128 = cipher.cbc_decrypt(iv, &encrypted_128[..]);
     assert_eq!(decrypted_128[..], plaintext[..]);
 
     // Test with AES-256 CBC
@@ -166,7 +166,7 @@ fn small_data() {
     let encrypted_256 = cipher.cbc_encrypt(iv, plaintext);
     assert_eq!(encrypted_256.len(), 16); // Verify padding
     assert_ne!(encrypted_256[..], encrypted_128[..]); // Verify AES-256 is different from AES-128
-    let decrypted_256 = cipher.cbc_decrypt(iv, &encrypted_256[..]).unwrap();
+    let decrypted_256 = cipher.cbc_decrypt(iv, &encrypted_256[..]);
     assert_eq!(decrypted_256[..], plaintext[..]);
 
     // Test with AES-192 CBC
@@ -175,7 +175,7 @@ fn small_data() {
     let encrypted_192 = cipher.cbc_encrypt(iv, plaintext);
     assert_eq!(encrypted_192.len(), 16); // Verify padding
     assert_ne!(encrypted_192[..], encrypted_256[..]); // Verify AES-192 is different from AES-256
-    let decrypted_192 = cipher.cbc_decrypt(iv, &encrypted_192[..]).unwrap();
+    let decrypted_192 = cipher.cbc_decrypt(iv, &encrypted_192[..]);
     assert_eq!(decrypted_192[..], plaintext[..]);
 
     // Test with AES-128 CFB128
@@ -231,7 +231,7 @@ fn large_data() {
                     And that has made all the difference.";
     let cipher = Cipher::new_128(key_128);
     let encrypted_128 = cipher.cbc_encrypt(iv, plaintext);
-    let decrypted_128 = cipher.cbc_decrypt(iv, &encrypted_128[..]).unwrap();
+    let decrypted_128 = cipher.cbc_decrypt(iv, &encrypted_128[..]);
     assert_eq!(decrypted_128[..], plaintext[..]);
 
     // Test with AES-256
@@ -240,7 +240,7 @@ fn large_data() {
     let encrypted_256 = cipher.cbc_encrypt(iv, plaintext);
     assert_eq!(encrypted_256.len(), encrypted_128.len());
     assert_ne!(encrypted_256[..], encrypted_128[..]);
-    let decrypted_256 = cipher.cbc_decrypt(iv, &encrypted_256[..]).unwrap();
+    let decrypted_256 = cipher.cbc_decrypt(iv, &encrypted_256[..]);
     assert_eq!(decrypted_256[..], plaintext[..]);
 
     // Test with AES-192
@@ -249,7 +249,7 @@ fn large_data() {
     let encrypted_192 = cipher.cbc_encrypt(iv, plaintext);
     assert_eq!(encrypted_192.len(), encrypted_256.len());
     assert_ne!(encrypted_192[..], encrypted_256[..]);
-    let decrypted_192 = cipher.cbc_decrypt(iv, &encrypted_192[..]).unwrap();
+    let decrypted_192 = cipher.cbc_decrypt(iv, &encrypted_192[..]);
     assert_eq!(decrypted_192[..], plaintext[..]);
 
     // Test with AES-128 CFB128
@@ -292,8 +292,5 @@ fn invalid_key_decrypt() {
     let invalid_key = b"k123456789012347";
     let cipher = Cipher::new_128(invalid_key);
     let decrypted_128 = cipher.cbc_decrypt(iv, &encrypted_128[..]);
-    assert!(decrypted_128.is_err());
-    let err = decrypted_128.unwrap_err();
-    let err_string = format!("{}", err);
-    assert!(err_string.contains("libaes.cbc_decrypt.UnpadError"));
+    assert!(decrypted_128.is_empty());
 }


### PR DESCRIPTION
After using the new version 0.5.0, I became not very satisfied with the [API change](https://github.com/keepsimple1/libaes/pull/10) was not very good, for two reasons:

1. From security point of view, I think it's better not to return a specific error if invalid key is used.
2. The API becomes more complex.

All things considered, I think it's better to just return an empty Vec if `unpad` failed.

Moving forward, I will try best to keep API stable.