### PR TITLE
Fix build warnings in recent Rust 1.69.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,7 +709,7 @@ fn aes_set_encrypt_key(user_key: &[u8], key_bits: u16, key: &mut AesKey) {
                 ^ (TE2[(temp >> 16) & 0xff] & 0xff000000)
                 ^ (TE3[(temp >> 8) & 0xff] & 0x00ff0000)
                 ^ (TE0[(temp) & 0xff] & 0x0000ff00)
-                ^ (TE1[(temp >> 24)] & 0x000000ff)
+                ^ (TE1[temp >> 24] & 0x000000ff)
                 ^ RCON[i];
             rk[5] = rk[1] ^ rk[4];
             rk[6] = rk[2] ^ rk[5];
@@ -735,7 +735,7 @@ fn aes_set_encrypt_key(user_key: &[u8], key_bits: u16, key: &mut AesKey) {
                 ^ (TE2[(temp >> 16) & 0xff] & 0xff000000)
                 ^ (TE3[(temp >> 8) & 0xff] & 0x00ff0000)
                 ^ (TE0[(temp) & 0xff] & 0x0000ff00)
-                ^ (TE1[(temp >> 24)] & 0x000000ff)
+                ^ (TE1[temp >> 24] & 0x000000ff)
                 ^ RCON[i];
             rk[7] = rk[1] ^ rk[6];
             rk[8] = rk[2] ^ rk[7];
@@ -764,7 +764,7 @@ fn aes_set_encrypt_key(user_key: &[u8], key_bits: u16, key: &mut AesKey) {
                 ^ (TE2[(temp >> 16) & 0xff] & 0xff000000)
                 ^ (TE3[(temp >> 8) & 0xff] & 0x00ff0000)
                 ^ (TE0[(temp) & 0xff] & 0x0000ff00)
-                ^ (TE1[(temp >> 24)] & 0x000000ff)
+                ^ (TE1[temp >> 24] & 0x000000ff)
                 ^ RCON[i];
             rk[9] = rk[1] ^ rk[8];
             rk[10] = rk[2] ^ rk[9];
@@ -777,7 +777,7 @@ fn aes_set_encrypt_key(user_key: &[u8], key_bits: u16, key: &mut AesKey) {
 
             let temp: usize = rk[11] as usize;
             rk[12] = rk[4]
-                ^ (TE2[(temp >> 24)] & 0xff000000)
+                ^ (TE2[temp >> 24] & 0xff000000)
                 ^ (TE3[(temp >> 16) & 0xff] & 0x00ff0000)
                 ^ (TE0[(temp >> 8) & 0xff] & 0x0000ff00)
                 ^ (TE1[(temp) & 0xff] & 0x000000ff);


### PR DESCRIPTION
Since our minimum Rust version is 1.46.0, these warnings were not reported in CI.

Warning log in Rust 1.69.0:
```
warning: unnecessary parentheses around index expression
   --> src/lib.rs:712:24
    |
712 |                 ^ (TE1[(temp >> 24)] & 0x000000ff)
    |                        ^          ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
712 -                 ^ (TE1[(temp >> 24)] & 0x000000ff)
712 +                 ^ (TE1[temp >> 24] & 0x000000ff)
    |

warning: unnecessary parentheses around index expression
   --> src/lib.rs:738:24
    |
738 |                 ^ (TE1[(temp >> 24)] & 0x000000ff)
    |                        ^          ^
    |
help: remove these parentheses
    |
738 -                 ^ (TE1[(temp >> 24)] & 0x000000ff)
738 +                 ^ (TE1[temp >> 24] & 0x000000ff)
    |

warning: unnecessary parentheses around index expression
   --> src/lib.rs:767:24
    |
767 |                 ^ (TE1[(temp >> 24)] & 0x000000ff)
    |                        ^          ^
    |
help: remove these parentheses
    |
767 -                 ^ (TE1[(temp >> 24)] & 0x000000ff)
767 +                 ^ (TE1[temp >> 24] & 0x000000ff)
    |

warning: unnecessary parentheses around index expression
   --> src/lib.rs:780:24
    |
780 |                 ^ (TE2[(temp >> 24)] & 0xff000000)
    |                        ^          ^
    |
help: remove these parentheses
    |
780 -                 ^ (TE2[(temp >> 24)] & 0xff000000)
780 +                 ^ (TE2[temp >> 24] & 0xff000000)
    |
```