### PR TITLE
bump up version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.7.0
+No breaking changes. Bumped the minor version because of a new API of padding.
+
+- support changing auto_padding setting in CBC mode (#30)
+
 # Version 0.6.5
 - Handles empty data gracefully in unpad() (#22)
 - Fix build warnings in recent Rust 1.69 (#23)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libaes"
-version = "0.6.5"
+version = "0.7.0"
 authors = ["Han Xu <keepsimple@gmail.com>"]
 edition = "2018"
 description = "AES cipher in safe Rust with no dependencies"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,11 @@ impl Cipher {
         }
     }
 
-    /// Changes the `auto_padding` setting of the cipher. Used in CBC mode.
-    /// Note that `auto_padding` is ignored in CFB mode.
+    /// Changes the `auto_padding` setting of the cipher. The default value is `true`.
+    ///
+    /// When setting it to `false`, the input data of CBC encryption must be multiple of `AES_BLOCK_SIZE`.
+    ///
+    /// And note that `auto_padding` is ignored in CFB mode.
     pub fn set_auto_padding(&mut self, auto_padding: bool) {
         self.auto_padding = auto_padding;
     }


### PR DESCRIPTION
The minor version is bumped because we are introducing a new API to change `auto_padding`.  This is not a breaking change though.